### PR TITLE
Add Missing JavaDoc Documentation For Non-Utility Classes

### DIFF
--- a/src/main/java/world/sc2/command/Command.java
+++ b/src/main/java/world/sc2/command/Command.java
@@ -8,7 +8,9 @@ import world.sc2.utility.ChatUtils;
 import java.util.List;
 
 /**
- * An abstract representation of a sub-command used after the base command of a {@link org.bukkit.plugin.Plugin}.
+ * An abstract representation of a subcommand used after the base command of a {@link org.bukkit.plugin.Plugin}. All
+ * Commands must have a {@link Config} with at least the "usage", "description", and "permission" keys filled out in
+ * order to function.
  */
 public abstract class Command {
 
@@ -18,18 +20,59 @@ public abstract class Command {
 
 	protected Config config;
 
+	/**
+	 * Constructs a new Command using the given {@link Config} as input for the usage, description, and permissions of
+	 * this Command.
+	 * @param config The Config of this command.
+	 */
 	public Command(Config config) {
 		this.config = config;
 	}
+
+	/**
+	 * Called whenever this Command is executed by a {@link CommandSender}. The first argument of this command will
+	 * always be the name of this Command, and thus the minimum size of args is 1.
+	 * @param sender The CommandSender who invoked this command.
+	 * @param args The arguments the sender invoked with this command call. The first element of this array is
+	 *             always the name of this Command.
+	 * @return true if this Command's syntax was used properly.
+	 */
 	public abstract boolean onCommand(CommandSender sender, String[] args);
+
+	/**
+	 * Called whenever a plugin's base command is prompted for a tab completion and this command's name was the first
+	 * argument of the base command. The first entry in args will always be the name of this Command.
+	 * @param sender The CommandSender that is typing this command.
+	 * @param args The arguments the user has already typed. The first element of this array will always be the name of
+	 *             this Command.
+	 * @return A List of Strings that represents the tab complete options of this command given they've already typed
+	 * the given arguments.
+	 */
 	public abstract List<String> onTabComplete(CommandSender sender, String[] args);
+
+	/**
+	 * Returns a String array of permissions that a CommandSender may have to execute this Command. If a CommandSender
+	 * has any one of these permissions, they have the ability to execute this command. This permissions array is
+	 * defined within this Command's {@link Config}.
+	 * @return The permission array of this Command defined within its Config.
+	 */
 	public String[] getRequiredPermission() {
 		List<String> permissions = config.get().getStringList(PERMISSION_KEY);
 		return permissions.toArray(new String[0]);
 	}
+
+	/**
+	 * Returns the usage message of this Command found within its {@link Config} with an added red escape code.
+	 * @return the usage message of this Command found within its {@link Config} with an added red escape code.
+	 */
 	public String getUsageMessage() {
 		return "&4" + config.get().get(USAGE_KEY);
 	}
+
+	/**
+	 * Returns the formatted help entry of this Command using this Command's {@link Config}.
+	 * @return the formatted help entry of this Command using this Command's {@link Config}.
+	 */
 	public String[] getHelpEntry() {
 		YamlConfiguration config = this.config.get();
 		return new String[]{

--- a/src/main/java/world/sc2/command/subcommand/HelpSubcommand.java
+++ b/src/main/java/world/sc2/command/subcommand/HelpSubcommand.java
@@ -8,12 +8,25 @@ import world.sc2.utility.ChatUtils;
 
 import java.util.*;
 
+/**
+ * A special {@link Subcommand} that is automatically generated for every plugin running chilly-lib. This command prints
+ * a messages that shows all registered commands for the plugins along with their usages and descriptions.
+ */
 public class HelpSubcommand extends Subcommand {
 	private final String invalid_number;
 	private final JavaPlugin plugin;
 	private final List<Subcommand> subcommands;
 
-	public HelpSubcommand(Config config, JavaPlugin plugin, Map<String, Subcommand> commands){
+	/**
+	 * Constructs a new HelpSubcommand from the given {@link Config}. This Config must contain the "usage",
+	 * "description", and "permission" fields. This HelpSubcommand also requires an instance of the plugin for which
+	 * this Subcommand is registered under as well as a Map of all subcommands registered under the plugin. This
+	 * subcommand is automatically constructed by the {@link SubcommandManager} class.
+	 * @param config The configuration file for this Subcommand.
+	 * @param plugin The instance of the plugin for which this HelpSubcommand is registered.
+	 * @param subcommands A Map of all Subcommands used by this plugin.
+	 */
+	public HelpSubcommand(Config config, JavaPlugin plugin, Map<String, Subcommand> subcommands){
 		super(config);
 
 		this.plugin = plugin;
@@ -21,8 +34,8 @@ public class HelpSubcommand extends Subcommand {
 		invalid_number = config.get().getString("messages.warning_invalid_number");
 
 		this.subcommands = new ArrayList<>();
-		for (String key : commands.keySet()) {
-			this.subcommands.add(commands.get(key));
+		for (String key : subcommands.keySet()) {
+			this.subcommands.add(subcommands.get(key));
 		}
 	}
 
@@ -118,6 +131,10 @@ public class HelpSubcommand extends Subcommand {
 		};
 	}
 
+	/**
+	 * Registers the given {@link Subcommand} into this HelpSubcommand.
+	 * @param subcommand the Subcommand to register into this HelpSubcommand.
+	 */
 	public void registerSubcommand(Subcommand subcommand) {
 		subcommands.add(subcommand);
 	}

--- a/src/main/java/world/sc2/command/subcommand/ReloadSubcommand.java
+++ b/src/main/java/world/sc2/command/subcommand/ReloadSubcommand.java
@@ -12,6 +12,10 @@ import world.sc2.utility.ChatUtils;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * A special {@link Subcommand} that is automatically generated for every plugin running chilly-lib. This command
+ * reloads all {@link Config}s for the plugin by calling {@link ConfigManager#reloadConfigs()}.
+ */
 public class ReloadSubcommand extends Subcommand {
 
 	private final ConfigManager configManager;

--- a/src/main/java/world/sc2/command/subcommand/Subcommand.java
+++ b/src/main/java/world/sc2/command/subcommand/Subcommand.java
@@ -21,35 +21,40 @@ public abstract class Subcommand {
 
 	protected Config config;
 
+	/**
+	 * Constructs a new Subcommand from the given {@link Config}. This Config must contain the "usage", "description",
+	 * and "permission" fields.
+	 * @param config The configuration file for this Subcommand.
+	 */
 	public Subcommand(Config config) {
 		this.config = config;
 	}
 
 	/**
-	 * Called whenever this Command is executed by a {@link CommandSender}. The first argument of this command will
-	 * always be the name of this Command, and thus the minimum size of args is 1.
-	 * @param sender The CommandSender who invoked this command.
-	 * @param args The arguments the sender invoked with this command call. The first element of this array is
-	 *             always the name of this Command.
-	 * @return true if this Command's syntax was used properly.
+	 * Called whenever this Subcommand is executed by a {@link CommandSender}. The first argument of this subcommand
+	 * will always be the name of this Subcommand, and thus the minimum size of args is 1.
+	 * @param sender The CommandSender who invoked this subcommand.
+	 * @param args The arguments the sender invoked with this subcommand call. The first element of this array is
+	 *             always the name of this Subcommand.
+	 * @return true if this Subcommand's syntax was used properly.
 	 */
 	public abstract boolean onCommand(CommandSender sender, String[] args);
 
 	/**
-	 * Called whenever a plugin's base command is prompted for a tab completion and this command's name was the first
-	 * argument of the base command. The first entry in args will always be the name of this Command.
-	 * @param sender The CommandSender that is typing this command.
+	 * Called whenever a plugin's base command is prompted for a tab completion and this subcommand's name was the first
+	 * argument of the base command. The first entry in args will always be the name of this Subcommand.
+	 * @param sender The CommandSender that is typing out the Subcommand.
 	 * @param args The arguments the user has already typed. The first element of this array will always be the name of
-	 *             this Command.
+	 *             this Subcommand.
 	 * @return A List of Strings that represents the tab complete options of this command given they've already typed
 	 * the given arguments.
 	 */
 	public abstract List<String> onTabComplete(CommandSender sender, String[] args);
 
 	/**
-	 * Returns a String array of permissions that a CommandSender may have to execute this Command. If a CommandSender
-	 * has any one of these permissions, they have the ability to execute this command. This permissions array is
-	 * defined within this Command's {@link Config}.
+	 * Returns a String array of permissions that a CommandSender may have to execute this Subcommand. If a
+	 * CommandSender has any one of these permissions, they have the ability to execute this command. This permissions
+	 * array is defined within this Command's {@link Config} under the "permissions" key.
 	 * @return The permission array of this Command defined within its Config.
 	 */
 	public String[] getRequiredPermission() {
@@ -58,16 +63,16 @@ public abstract class Subcommand {
 	}
 
 	/**
-	 * Returns the usage message of this Command found within its {@link Config} with an added red escape code.
-	 * @return the usage message of this Command found within its {@link Config} with an added red escape code.
+	 * Returns the usage message of this Subcommand found within its {@link Config} with an added red escape code.
+	 * @return the usage message of this Subcommand found within its {@link Config} with an added red escape code.
 	 */
 	public String getUsageMessage() {
 		return "&4" + config.get().get(USAGE_KEY);
 	}
 
 	/**
-	 * Returns the formatted help entry of this Command using this Command's {@link Config}.
-	 * @return the formatted help entry of this Command using this Command's {@link Config}.
+	 * Returns the formatted help entry of this Subcommand using this Subcommand's {@link Config}.
+	 * @return the formatted help entry of this Subcommand using this Subcommand's {@link Config}.
 	 */
 	public String[] getHelpEntry() {
 		YamlConfiguration config = this.config.get();

--- a/src/main/java/world/sc2/command/subcommand/Subcommand.java
+++ b/src/main/java/world/sc2/command/subcommand/Subcommand.java
@@ -9,7 +9,9 @@ import java.util.List;
 
 /**
  * An abstract representation of a subcommand used after the {@link world.sc2.command.BaseCommand} of a plugin. Each
- * subcommand is designed to be treated similar to a normal paper-spigot Command.
+ * subcommand is designed to be treated similar to a normal paper-spigot Command. All
+ * Commands must have a {@link Config} with at least the "usage", "description", and "permission" keys filled out in
+ * order to function.
  */
 public abstract class Subcommand {
 
@@ -22,15 +24,51 @@ public abstract class Subcommand {
 	public Subcommand(Config config) {
 		this.config = config;
 	}
+
+	/**
+	 * Called whenever this Command is executed by a {@link CommandSender}. The first argument of this command will
+	 * always be the name of this Command, and thus the minimum size of args is 1.
+	 * @param sender The CommandSender who invoked this command.
+	 * @param args The arguments the sender invoked with this command call. The first element of this array is
+	 *             always the name of this Command.
+	 * @return true if this Command's syntax was used properly.
+	 */
 	public abstract boolean onCommand(CommandSender sender, String[] args);
+
+	/**
+	 * Called whenever a plugin's base command is prompted for a tab completion and this command's name was the first
+	 * argument of the base command. The first entry in args will always be the name of this Command.
+	 * @param sender The CommandSender that is typing this command.
+	 * @param args The arguments the user has already typed. The first element of this array will always be the name of
+	 *             this Command.
+	 * @return A List of Strings that represents the tab complete options of this command given they've already typed
+	 * the given arguments.
+	 */
 	public abstract List<String> onTabComplete(CommandSender sender, String[] args);
+
+	/**
+	 * Returns a String array of permissions that a CommandSender may have to execute this Command. If a CommandSender
+	 * has any one of these permissions, they have the ability to execute this command. This permissions array is
+	 * defined within this Command's {@link Config}.
+	 * @return The permission array of this Command defined within its Config.
+	 */
 	public String[] getRequiredPermission() {
 		List<String> permissions = config.get().getStringList(PERMISSION_KEY);
 		return permissions.toArray(new String[0]);
 	}
+
+	/**
+	 * Returns the usage message of this Command found within its {@link Config} with an added red escape code.
+	 * @return the usage message of this Command found within its {@link Config} with an added red escape code.
+	 */
 	public String getUsageMessage() {
 		return "&4" + config.get().get(USAGE_KEY);
 	}
+
+	/**
+	 * Returns the formatted help entry of this Command using this Command's {@link Config}.
+	 * @return the formatted help entry of this Command using this Command's {@link Config}.
+	 */
 	public String[] getHelpEntry() {
 		YamlConfiguration config = this.config.get();
 		return new String[]{

--- a/src/main/java/world/sc2/command/subcommand/SubcommandManager.java
+++ b/src/main/java/world/sc2/command/subcommand/SubcommandManager.java
@@ -10,6 +10,10 @@ import world.sc2.config.ConfigManager;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * The manager of all {@link Subcommand} related tasks. Individual plugins must construct this SubcommandManager and
+ * individually register each of the Subcommands they create.
+ */
 public class SubcommandManager {
 
 	private static final String COMMAND_CONFIG_DIRECTORY_PATH = "commands";

--- a/src/main/java/world/sc2/config/Config.java
+++ b/src/main/java/world/sc2/config/Config.java
@@ -9,6 +9,12 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 
+/**
+ * A representation of a YAML configuration file within a {@link org.bukkit.plugin.Plugin}'s jar file or data directory.
+ * Each Config has an internal {@link YamlConfiguration} file and contains methods for saving this Config and reloading
+ * the Config into the game. The YamlConfiguration returned by {@link Config#get()} may change after calling the
+ * {@link Config#reload()} command.
+ */
 public class Config {
     private final String name;
     private File file;
@@ -44,8 +50,9 @@ public class Config {
     }
 
     /**
-     * Saves the config stored within the plugin's jar file into its data directory. Throws an exception if this config
-     * does not exist within the plugin's jar file.
+     * Saves the config stored within the plugin's jar file into its data directory. This method will not replace a
+     * configuration file if it is already present. Throws an exception if this config does not exist within the
+     * plugin's jar file.
      * @return This instance of Config.
      */
     public Config saveDefaultConfig() {
@@ -56,6 +63,12 @@ public class Config {
         return this;
     }
 
+    /**
+     * Reloads this Config to reflect any external changes made to it since instantiation. If the YamlConfiguration
+     * stored within the plugin's data directory is missing some keys present within the plugin's jar file, then the
+     * values of those keys will be copied over as the default values of this Config.
+     * @return This Config.
+     */
     public Config reload() {
         if (file == null)
             this.file = new File(plugin.getDataFolder(), this.name);
@@ -75,16 +88,34 @@ public class Config {
         return this;
     }
 
+    /**
+     *
+     * @param force
+     * @return
+     */
     public Config copyDefaults(boolean force) {
         get().options().copyDefaults(force);
         return this;
     }
 
+    /**
+     * A convenience method for setting a key-value pair inside the internal {@link YamlConfiguration} of this Config.
+     * @param key The key to set
+     * @param value The value to set
+     * @return This Config
+     */
     public Config set(String key, Object value) {
         get().set(key, value);
         return this;
     }
 
+    /**
+     * A convenience method for getting the value of a key-value pair inside the internal {@link YamlConfiguration} of
+     * this Config.
+     * @param key The key to get the value from.
+     * @return The Object stored at the given key within this Config's YamlConfiguration, or null if the key does not
+     * exist within the YamlConfiguration.
+     */
     public Object get(String key) {
         return get().get(key);
     }

--- a/src/main/java/world/sc2/config/ConfigManager.java
+++ b/src/main/java/world/sc2/config/ConfigManager.java
@@ -6,21 +6,44 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 
-//All credit to spigotmc.org user Bimmr for this manager
+
+/**
+ * A manager for all {@link Config} related tasks. Individual plugins must construct this ConfigManager. There should
+ * only be one instance of ConfigManager per plugin, and that instance should be passed around using dependency
+ * injection.
+ * @author Bimmr
+ */
 public class ConfigManager {
 
     private final JavaPlugin plugin;
-    private final HashMap<String, Config> configs = new HashMap<>();
+    private final Map<String, Config> configs = new HashMap<>();
 
+    /**
+     * Constructs a new ConfigManager for the given {@link JavaPlugin}. There should only be one ConfigManager per
+     * plugin, and this instance of ConfigManager should be passed around using dependency injection.
+     * @param plugin The plugin to create this ConfigManager for.
+     */
     public ConfigManager(JavaPlugin plugin) {
         this.plugin = plugin;
     }
 
-    public HashMap<String, Config> getConfigs() {
+    /**
+     * Returns the internal Map of all {@link Config} files registered with this ConfigManager.
+     * @return the internal Map of all Config files registered with this ConfigManager.
+     */
+    public Map<String, Config> getConfigs() {
         return configs;
     }
 
+    /**
+     * Returns the {@link Config} with the given name. If no Config registered with this ConfigManager has the given
+     * name, then a new Config is created and registered with this ConfigManager using the given name.
+     * @param name The name of the Config to return.
+     * @return The Config value stored within the Config map in this ConfigManager for the given name, or a new Config
+     * with the given name if it does not exist within that map.
+     */
     public Config getConfig(String name) {
         if (!configs.containsKey(name))
             configs.put(name, new Config(plugin, name));
@@ -28,16 +51,28 @@ public class ConfigManager {
         return configs.get(name);
     }
 
+    /**
+     * Reloads the {@link Config} with the given name. Exactly the same as instead calling getConfig(name).reload().
+     * @param name The name of this Config.
+     * @return The Config that was reloaded.
+     */
     public Config reloadConfig(String name) {
         return getConfig(name).reload();
     }
 
+    /**
+     * Reloads every {@link Config} registered with this ConfigManager by calling {@link Config#reload()}.
+     */
     public void reloadConfigs() {
-        for (String config : configs.keySet()){
-            configs.get(config).reload();
+        for (Config config : configs.values()){
+            config.reload();
         }
     }
 
+    /**
+     * Saves every {@link Config} registered within this ConfigManager by internally calling saveConfig(name) for each
+     * individual Config name.
+     */
     public void saveConfigs() {
         for (String config : configs.keySet()) {
             saveConfig(config);
@@ -72,7 +107,8 @@ public class ConfigManager {
     }
 
     /**
-     * Updates a config by comparing in the plugin's assigned data folder by copying over data from the jar file
+     * Updates a Config by comparing it to the plugin in the plugin's assigned data folder and copying over any missing
+     * data from the jar file.
      * @param name The path to the config from the plugin's assigned data file
      */
     public void updateConfig(String name) {
@@ -85,7 +121,8 @@ public class ConfigManager {
     }
 
     /**
-     * Saves and updates the given config
+     * Saves and updates the given config within this ConfigManager. equivalent to calling saveConfig(name) and then
+     * updateConfig(name).
      * @param name The path to the config from the plugin's assigned data file
      */
     public void saveAndUpdateConfig(String name) {

--- a/src/main/java/world/sc2/config/ConfigUpdater.java
+++ b/src/main/java/world/sc2/config/ConfigUpdater.java
@@ -24,7 +24,7 @@ public class ConfigUpdater {
 
     /**
      * Update a yaml file from a resource inside your plugin jar
-     * @param plugin You plugin
+     * @param plugin Your plugin
      * @param resourceName The yaml file name to update from, typically config.yml
      * @param toUpdate The yaml file to update
      * @param ignoredSections List of sections to ignore and copy from the current config


### PR DESCRIPTION
Adds documentation for all chilly-lib classes not in the utility package.