### PR TITLE
Move Color from GetUsageMessage to Outside of the Method

### DIFF
--- a/src/main/java/world/sc2/command/BaseCommand.java
+++ b/src/main/java/world/sc2/command/BaseCommand.java
@@ -81,7 +81,7 @@ public class BaseCommand implements TabExecutor {
                     return true;
                 }
                 if (!commandMap.get(subCommand).onCommand(sender, args)) {
-                    sender.sendMessage(ChatUtils.chat(commandMap.get(subCommand).getUsageMessage()));
+                    sender.sendMessage(ChatUtils.chat("&4" + commandMap.get(subCommand).getUsageMessage()));
                 }
                 return true;
             }

--- a/src/main/java/world/sc2/command/subcommand/Subcommand.java
+++ b/src/main/java/world/sc2/command/subcommand/Subcommand.java
@@ -63,11 +63,11 @@ public abstract class Subcommand {
 	}
 
 	/**
-	 * Returns the usage message of this Subcommand found within its {@link Config} with an added red escape code.
-	 * @return the usage message of this Subcommand found within its {@link Config} with an added red escape code.
+	 * Returns the usage message of this Subcommand found within its {@link Config}.
+	 * @return the usage message of this Subcommand found within its {@link Config}.
 	 */
 	public String getUsageMessage() {
-		return "&4" + config.get().get(USAGE_KEY);
+		return "" + config.get().get(USAGE_KEY);
 	}
 
 	/**


### PR DESCRIPTION
Done! There is no longer a color code tacked onto the beginning of Subcommand#getUsageMessage.